### PR TITLE
Creating a phar package and a command line tool

### DIFF
--- a/bin/profile2html
+++ b/bin/profile2html
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php
+
+foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+    if (file_exists($file)) {
+        define('XAPI_PROFILE2HTML_COMPOSER_INSTALL', $file);
+        break;
+    }
+}
+
+unset($file);
+
+if (!defined('XAPI_PROFILE2HTML_COMPOSER_INSTALL')) {
+    fwrite(
+        STDERR,
+        'You need to set up the project dependencies using Composer:' . PHP_EOL . PHP_EOL .
+        '    composer install' . PHP_EOL . PHP_EOL .
+        'You can learn all about Composer on https://getcomposer.org/.' . PHP_EOL
+    );
+    die(1);
+}
+
+require XAPI_PROFILE2HTML_COMPOSER_INSTALL;
+
+es\eucm\xapi\command\Command::main();

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="phpunit" default="setup">
+    <target name="setup" depends="clean,installDependencies"/>
+
+    <target name="clean" unless="clean.done" description="Cleanup build artifacts">
+        <delete dir="${basedir}/build/phar"/>
+        <delete>
+            <fileset dir="${basedir}/build">
+                <include name="**/profile2html*.phar"/>
+                <include name="**/profile2html*.phar.asc"/>
+            </fileset>
+        </delete>
+
+        <property name="clean.done" value="true"/>
+    </target>
+
+    <target name="checkDependenciesInstalled">
+        <condition property="dependenciesInstalled">
+            <and>
+                <available file="${basedir}/composer.lock" />
+                <available file="${basedir}/vendor" />
+            </and>
+        </condition>
+    </target>
+
+    <target name="validateComposerJson" unless="composerJsonValidated" description="Validate composer.json">
+        <exec executable="composer" failonerror="true" taskname="composer">
+            <arg value="validate"/>
+            <arg value="--strict"/>
+            <arg value="${basedir}/composer.json"/>
+        </exec>
+
+        <property name="composerJsonValidated" value="true"/>
+    </target>
+
+    <target name="pharDetermineVersion">
+        <exec executable="${basedir}/build/version.php" outputproperty="version" />
+    </target>
+
+    <target name="installDependencies" unless="dependenciesInstalled" depends="checkDependenciesInstalled,validateComposerJson" description="Install dependencies with Composer">
+        <exec executable="composer" taskname="composer">
+            <arg value="update"/>
+            <arg value="--no-interaction"/>
+            <arg value="--no-progress"/>
+            <arg value="--no-ansi"/>
+            <arg value="--no-suggest"/>
+            <arg value="--optimize-autoloader"/>
+            <arg value="--prefer-stable"/>
+        </exec>
+    </target>
+
+    <target name="pharPrepareBuild" depends="clean,installDependencies">
+        <mkdir dir="${basedir}/build/phar"/>
+
+        <copy file="${basedir}/vendor/sebastian/version/LICENSE" tofile="${basedir}/build/phar/sebastian-version/LICENSE"/>
+        <copy todir="${basedir}/build/phar/sebastian-version">
+            <fileset dir="${basedir}/vendor/sebastian/version/src">
+                <include name="**/*.php" />
+            </fileset>
+        </copy>
+
+    </target>
+
+    <target name="pharBuild" depends="pharDetermineVersion">
+        <copy todir="${basedir}/build/phar/profile2html">
+            <fileset dir="${basedir}/src">
+                <include name="**/*.php"/>
+            </fileset>
+        </copy>
+
+        <exec executable="${basedir}/build/phar-version.php" outputproperty="_version">
+            <arg value="${version}"/>
+            <arg value="${type}"/>
+        </exec>
+
+        <exec executable="${basedir}/vendor/bin/phpab" taskname="phpab">
+            <arg value="--all" />
+            <arg value="--static" />
+            <arg value="--once" />
+            <arg value="--phar" />
+            <arg value="--hash" />
+            <arg value="SHA-1" />
+            <arg value="--output" />
+            <arg path="${basedir}/build/profile2html-${_version}.phar" />
+            <arg value="--template" />
+            <arg path="${basedir}/build/phar-autoload.php.in" />
+            <arg path="${basedir}/build/phar" />
+        </exec>
+        <chmod file="${basedir}/build/profile2html-${_version}.phar" perm="ugo+rx"/>
+    </target>
+
+    <target name="phar" depends="pharDetermineVersion,pharPrepareBuild" description="Create PHAR archive of profile2html and all its dependencies">
+        <antcall target="pharBuild" >
+            <param name="type" value="release"/>
+        </antcall>
+    </target>
+
+    <target name="signedPhar" depends="phar" description="Create signed PHAR archive of profile2html and all its dependencies">
+        <exec executable="gpg" failonerror="true">
+            <arg value="--local-user"/>
+            <arg value="0x3924202A"/>
+            <arg value="--armor"/>
+            <arg value="--detach-sign"/>
+            <arg path="${basedir}/build/profile2html-${version}.phar"/>
+        </exec>
+    </target>
+</project>

--- a/build/phar-autoload.php.in
+++ b/build/phar-autoload.php.in
@@ -1,0 +1,10 @@
+#!/usr/bin/env php
+<?php
+
+Phar::mapPhar('___PHAR___');
+
+___FILELIST___
+
+es\eucm\xapi\command\Command::main();
+
+__HALT_COMPILER();

--- a/build/phar-version.php
+++ b/build/phar-version.php
@@ -1,0 +1,18 @@
+#!/usr/bin/env php
+<?php
+if (!isset($argv[1]) || !isset($argv[2])) {
+    exit(1);
+}
+\file_put_contents(
+    __DIR__ . '/phar/profile2html/command/Version.php',
+    \str_replace(
+        'private static $pharVersion;',
+        'private static $pharVersion = "' . $argv[1] . '";',
+        \file_get_contents(__DIR__ . '/phar/profile2html/command/Version.php')
+    )
+);
+if ($argv[2] == 'release') {
+    print $argv[1];
+} else {
+    print $argv[2];
+}

--- a/build/version.php
+++ b/build/version.php
@@ -1,0 +1,12 @@
+#!/usr/bin/env php
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+use SebastianBergmann\Version;
+
+$buffer  = \file_get_contents(__DIR__ . '/../src/command/Version.php');
+$start   = \strpos($buffer, 'new VersionId(\'') + \strlen('new VersionId(\'');
+$end     = \strpos($buffer, '\'', $start);
+$version = \substr($buffer, $start, $end - $start);
+$version = new Version($version, __DIR__ . '/../');
+print $version->getVersion();

--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,9 @@
     },
     "autoload": {
         "psr-4": {"es\\eucm\\xapi\\": "src/"}
+    },
+    "require-dev": {
+        "theseer/autoload": "^1.23",
+        "sebastian/version": "^2.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name" : "e-ucm/xapi-profile2html",
-    "version" : "0.4.0",
     "description": "HTML generator for xAPI JSON-LD profiles",
     "keywords": ["xapi","profile", "generator"],
     "homepage": "https://github.com/e-ucm/xapi-profile2html",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "HTML generator for xAPI JSON-LD profiles",
     "keywords": ["xapi","profile", "generator"],
     "homepage": "https://github.com/e-ucm/xapi-profile2html",
-    "license": "Apache 2",
+    "license": "Apache-2.0",
     "authors": [
         {
             "name": "Ivan Martinez-Ortiz",

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,279 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "1ac0bc3bae2a476d31f1fa0798454744",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "theseer/autoload",
+            "version": "1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/Autoload.git",
+                "reference": "4466c1d32c2dadb40cbe598b656a485e6175a00d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/Autoload/zipball/4466c1d32c2dadb40cbe598b656a485e6175a00d",
+                "reference": "4466c1d32c2dadb40cbe598b656a485e6175a00d",
+                "shasum": ""
+            },
+            "require": {
+                "theseer/directoryscanner": "~1.3",
+                "zetacomponents/console-tools": "~1.7"
+            },
+            "require-dev": {
+                "php": ">=5.3",
+                "phpunit/phpunit": "~4.0|~5.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "bin": [
+                "composer/bin/phpab"
+            ],
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD License"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de"
+                }
+            ],
+            "description": "A tool and library to generate autoload code.",
+            "time": "2016-12-20T20:42:09+00:00"
+        },
+        {
+            "name": "theseer/directoryscanner",
+            "version": "1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/DirectoryScanner.git",
+                "reference": "549aa9fdbc47d50365db42d9ade35fdef65f854c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/DirectoryScanner/zipball/549aa9fdbc47d50365db42d9ade35fdef65f854c",
+                "reference": "549aa9fdbc47d50365db42d9ade35fdef65f854c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A recursive directory scanner and filter",
+            "time": "2015-03-24T21:28:20+00:00"
+        },
+        {
+            "name": "zetacomponents/base",
+            "version": "1.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zetacomponents/Base.git",
+                "reference": "f20df24e8de3e48b6b69b2503f917e457281e687"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zetacomponents/Base/zipball/f20df24e8de3e48b6b69b2503f917e457281e687",
+                "reference": "f20df24e8de3e48b6b69b2503f917e457281e687",
+                "shasum": ""
+            },
+            "require-dev": {
+                "zetacomponents/unit-test": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sergey Alexeev"
+                },
+                {
+                    "name": "Sebastian Bergmann"
+                },
+                {
+                    "name": "Jan Borsodi"
+                },
+                {
+                    "name": "Raymond Bosman"
+                },
+                {
+                    "name": "Frederik Holljen"
+                },
+                {
+                    "name": "Kore Nordmann"
+                },
+                {
+                    "name": "Derick Rethans"
+                },
+                {
+                    "name": "Vadym Savchuk"
+                },
+                {
+                    "name": "Tobias Schlitt"
+                },
+                {
+                    "name": "Alexandru Stanoi"
+                }
+            ],
+            "description": "The Base package provides the basic infrastructure that all packages rely on. Therefore every component relies on this package.",
+            "homepage": "https://github.com/zetacomponents",
+            "time": "2014-09-19T03:28:34+00:00"
+        },
+        {
+            "name": "zetacomponents/console-tools",
+            "version": "1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zetacomponents/ConsoleTools.git",
+                "reference": "30d67e9d04f458ac8cae4c49e50f81061460ff2c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zetacomponents/ConsoleTools/zipball/30d67e9d04f458ac8cae4c49e50f81061460ff2c",
+                "reference": "30d67e9d04f458ac8cae4c49e50f81061460ff2c",
+                "shasum": ""
+            },
+            "require": {
+                "zetacomponents/base": "~1.8"
+            },
+            "require-dev": {
+                "zetacomponents/unit-test": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sergey Alexeev"
+                },
+                {
+                    "name": "Sebastian Bergmann"
+                },
+                {
+                    "name": "Jan Borsodi"
+                },
+                {
+                    "name": "Raymond Bosman"
+                },
+                {
+                    "name": "Frederik Holljen"
+                },
+                {
+                    "name": "Kore Nordmann"
+                },
+                {
+                    "name": "Derick Rethans"
+                },
+                {
+                    "name": "Vadym Savchuk"
+                },
+                {
+                    "name": "Tobias Schlitt"
+                },
+                {
+                    "name": "Alexandru Stanoi"
+                }
+            ],
+            "description": "A set of classes to do different actions with the console (also called shell). It can render a progress bar, tables and a status bar and contains a class for parsing command line options.",
+            "homepage": "https://github.com/zetacomponents",
+            "time": "2014-09-27T19:26:09+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.0"
+    },
+    "platform-dev": []
+}

--- a/src/command/Command.php
+++ b/src/command/Command.php
@@ -1,0 +1,34 @@
+<?php
+namespace es\eucm\xapi\command;
+
+use es\eucm\xapi\Profile2Html;
+
+class Command
+{
+    static public function main()
+    {
+        $command = new self;
+        $command->run($_SERVER['argv']);
+    }
+
+    private function run(array $argv)
+    {
+        if (count($argv) < 2) {
+            fwrite(STDERR, "path to xapi profile (.jsonld) expected.\n");
+            exit(1);
+        }
+        $profileFile=$argv[1];
+        if (! is_readable($profileFile)) {
+            fwrite(STDERR, sprintf("'%s' does not exists or is not readable.\n", $profileFile));
+            exit(1);
+        }
+
+        if (! is_file($profileFile)) {
+            fwrite(STDERR, sprintf("'%s' does not exists or is not a file.\n", $profileFile));
+            exit(1);
+        }
+
+        $generator = new Profile2Html();
+        echo $generator->generate($profileFile);
+    }
+}

--- a/src/command/Version.php
+++ b/src/command/Version.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace es\eucm\xapi\command;
+
+use SebastianBergmann\Version as VersionId;
+
+class Version
+{
+
+    private static $pharVersion;
+
+    private static $version;
+
+    public static function id()
+    {
+        if (self::$pharVersion !== null) {
+            return self::$pharVersion;
+        }
+        if (self::$version === null) {
+            $version       = new VersionId('0.4', \dirname(\dirname(__DIR__)));
+            self::$version = $version->getVersion();
+        }
+        return self::$version;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getVersionString()
+    {
+        return 'PHPUnit ' . self::id() . ' by e-UCM Team';
+    }
+
+    /**
+     * @return string
+     */
+    public static function getReleaseChannel()
+    {
+        if (\strpos(self::$pharVersion, '-') !== false) {
+            return '-nightly';
+        }
+        return '';
+    }
+}

--- a/src/command/Version.php
+++ b/src/command/Version.php
@@ -18,7 +18,7 @@ class Version
             return self::$pharVersion;
         }
         if (self::$version === null) {
-            $version       = new VersionId('0.4', \dirname(\dirname(__DIR__)));
+            $version       = new VersionId('0.5.0', \dirname(\dirname(__DIR__)));
             self::$version = $version->getVersion();
         }
         return self::$version;


### PR DESCRIPTION
This PR provides a command line tool ```profile2html``` that can be used to transform the xAPI profiles to HTML. In addition, the PR also include all the machinery needed to build a PHP Phar package for the command line tool in order to facilitate its distribution and usage.

Steps to test the PR (preferable in Linux):
1. install PHP composer
2. install ant
3. run ```ant phar```
4. run ```./build/profile2html-XXXX.phar <path to .jsonld>```